### PR TITLE
correction of download command for captioner-library

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you use RStudio, you can press Cmd/Ctrl + Shift + B to run make.
 There are a number of dependencies required to build this book. We have a full installation recipe for ubuntu 12.04 [here](https://github.com/hadley/ggplot2-book/blob/master/.travis.yml). Even if you run a different operating system, please look there for R package requirements. Most of the R packages are available on CRAN via `install.packages` except for [bookdown](https://github.com/hadley/bookdown) and [captioner](https://github.com/adletaw/captioner). You can install both with:
 
 ```r
-devtools::install_github(c("adletaw/captioner/captioner", "hadley/bookdown"))
+devtools::install_github(c("adletaw/captioner", "hadley/bookdown"))
 ```
 
 You might also need to install the [inconsolata](http://www.ctan.org/tex-archive/fonts/inconsolata/) font.


### PR DESCRIPTION
If not corrected you get the following error:
> Downloading github repo adletaw/captioner@master
> Fehler: Does not appear to be an R package (no DESCRIPTION)