### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ devtools::install_deps("path/to/ggplot2-book", dependencies = TRUE)
 There are also a couple GitHub packages which we depend on:
 
 ```r
-devtools::install_github(c("adletaw/captioner", "hadley/bookdown"))
+devtools::install_github(c("adletaw/captioner", "hadley/bookdown", "hadley/devtools"))
 ```
 
 ## Internal links


### PR DESCRIPTION
you updated session_info() to take package names in commit 7234292caab972955d0e5dd57cf1c0b4671587a5 (around may 1st), which is leveraged in introduction.Rmd to show the ggplot2/dplyr versions. If a person has the CRAN or an older development version of devtools the build will fail.

I am unsure if install_github has a check for only reinstalling if a version predates a certain commit so seems reasonable to just have them install the most updated version?
