### PR TITLE
babynames package is needed for the build

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,5 +24,6 @@ Imports:
   rmarkdown,
   Lahman,
   ggmap,
-  directlabels
+  directlabels,
+  babynames
 SystemRequirements: pandoc (>= 1.12.3) - http://johnmacfarlane.net/pandoc


### PR DESCRIPTION
The babynames package had to be installed for the build. 