### PR TITLE
fix to `separate`

### DIFF
--- a/tidy-data.rmd
+++ b/tidy-data.rmd
@@ -247,7 +247,7 @@ bpd_1
 This is tidier, but we have two variables combined together in the `bp` variable. This is a common way of writing down the blood pressure, but analysis is easier if we break into two variables.  That's the job of separate:
 
 ```{r bp2}
-bpd_2 <- separate(bpd_1, bp, c("sys", "dia"), "/")
+bpd_2 <- separate(bpd_1, bp, c("sys", "dia"), "/", extra = "drop")
 bpd_2
 ```
 


### PR DESCRIPTION
`separate` with NAs without `extra = "drop"` throws an error