### PR TITLE
Typos in toolbox.tex

### DIFF
--- a/book/tex/toolbox.tex
+++ b/book/tex/toolbox.tex
@@ -1019,7 +1019,7 @@ For interactive 3d plots, including true 3d surfaces, see RGL,
 There are four types of map data you might want to visualise: vector
 boundaries, point metadata, area metadata, and raster images. Typically,
 assembling these datasets is the most challenging part of drawing maps.
-Unforuntately ggplot2 can help you with that part of the analysis, but
+Unfortunately ggplot2 cannot help you with that part of the analysis, but
 I'll provide some hints about other R packages that you might want to
 look at.
 


### PR DESCRIPTION
Fixed a spelling-type, and replaced "can" with the probably intended "cannot".