### PR TITLE
Use stat_count() for discrete variable

### DIFF
--- a/layers.rmd
+++ b/layers.rmd
@@ -542,7 +542,7 @@ There's also a position adjustment that does nothing: `position_identity()`. The
 dplot + geom_bar(position = "identity", alpha = 1 / 2, colour = "grey50")
 
 ggplot(diamonds, aes(color, colour = cut)) + 
-  geom_freqpoly(aes(group = cut)) + 
+  geom_freqpoly(aes(group = cut), stat = "count") + 
   xlab(NULL) + ylab(NULL) + 
   theme(legend.position = "none")
 ```


### PR DESCRIPTION
This pull request fixes https://github.com/hadley/ggplot2-book/issues/93.

This code no longer works since StatBin requires a continuous x variable, while `color` is discrete. `stat="count"` should be specified.

```r
ggplot(diamonds, aes(color, colour = cut)) + 
  geom_freqpoly(aes(group = cut)) + 
```

