### PR TITLE
Remove terminal characters, use bash highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ This is code and text behind the [ggplot2](http://ggplot2.org/book/) book. Pleas
 
 You can build the pdf by cloning this repo and running make:
 
-```
-$ git clone https://github.com/hadley/ggplot2-book.git
-$ cd ggplot2-book
-$ make clean
-$ make
+```bash
+git clone https://github.com/hadley/ggplot2-book.git
+cd ggplot2-book
+make clean
+make
 ```
 
 If you use RStudio, you can press Cmd/Ctrl + Shift + B to run make.


### PR DESCRIPTION
Otherwise you have to remove them manually if you copy-paste the instructions.