### PR TITLE
Update installation steps for R dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To successfully build this book, you'll need:
 Install the R dependencies with:
 
 ```r
+library(devtools)
 if (packageVersion("devtools") < "1.9.1") {
   message("Please upgrade devtools")
 }


### PR DESCRIPTION
Clarify that the devtools library must be loaded before R dependencies can be installed.