### PR TITLE
change coord_trans(ytrans=..) to coord_trans(y=..)

### DIFF
--- a/mastery.rmd
+++ b/mastery.rmd
@@ -228,7 +228,7 @@ p <- ggplot(df, aes(x1, y1)) +
   scale_y_continuous(NULL) +
   theme_linedraw()
 p 
-p + coord_trans(ytrans = "log10")
+p + coord_trans(y = "log10")
 p + coord_polar()
 ```
 


### PR DESCRIPTION
during  compiling and tex'ing the book , there was this error:
Error: `ytrans` arguments is deprecated; please use `y` instead. (Defunct; last used in version 1.0.1)

I have   
`packageVersion("ggplot2")`
`[1] ‘2.0.0’. `

R version 3.2.2 (2015-08-14)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: Ubuntu 15.10`