### PR TITLE
Corrected a few typos in Ch. 1-6 (mostly in exercises statements)

### DIFF
--- a/ggplot.rmd
+++ b/ggplot.rmd
@@ -71,7 +71,7 @@ This dataset suggests many interesting questions. How are engine size and fuel e
     fixed amount of fuel). How could you convert `cty` and `hwy` into the
     European standard of l/100km? 
     
-1.  Which manufacturer has the most the models in this dataset? Which model has 
+1.  Which manufacturer has the most models in this dataset? Which model has 
     the most variations? Does your answer change if you remove the redundant
     specification of drive train (e.g. "pathfinder 4wd", "a4 quattro") from the 
     model name?

--- a/layers.rmd
+++ b/layers.rmd
@@ -266,7 +266,7 @@ ggplot(mpg, aes(displ, hwy)) +
 
     ```{r, eval = FALSE}
     ggplot(mpg) + 
-      geom_point(aes(mpg$disp, mpg$hwy))
+      geom_point(aes(mpg$displ, mpg$hwy))
     
     ggplot() + 
      geom_point(mapping = aes(y = hwy, x = cty), data = mpg) +

--- a/scales.rmd
+++ b/scales.rmd
@@ -783,7 +783,7 @@ There are four continuous colour scales:
     make them unevenly spaced, use the `values` argument, which should be a 
     vector of values between 0 and 1.
 
-*   `scale_color_distiller()` and `scale_fill_gradient()` apply the ColorBrewer 
+*   `scale_color_distiller()` and `scale_fill_distiller()` apply the ColorBrewer 
     colour scales to continuous data. You use it the same way as
     `scale_fill_brewer()`, described below:
 

--- a/toolbox.rmd
+++ b/toolbox.rmd
@@ -554,7 +554,7 @@ The bars will be stacked in the order defined by the grouping variable. If you n
     `cyl` into a factor. What extra aesthetic do you need to set?
     
 1.  Modify the following plot so that you get one boxplot per integer value 
-    value of `displ`.
+    of `displ`.
     
     ```{r, eval = FALSE}
     ggplot(mpg, aes(displ, cty)) + 


### PR DESCRIPTION
Corrected typos:

* "the most the models" to "the most models"
* "value value" double word to a single word
* `mpg$disp` to `mpg$displ`
* "`scale_color_distiller()` and `scale_fill_gradient()` apply the ColorBrewer (...)" changed to "`scale_color_distiller()` and `scale_fill_distiller()` apply the ColorBrewer (...)"