### PR TITLE
Update toolbox.rmd

### DIFF
--- a/toolbox.rmd
+++ b/toolbox.rmd
@@ -678,17 +678,15 @@ Other useful sources of vector boundary data are:
 * You may have your own shape files (`.shp`). You can load them into
   R with `maptools::readShapeSpatial()`.
   
-These sources all generate spatial data frames defined by the sp package. You can convert them into a data frame with `fortify()`:
+All but one of these sources generate spatial data frames defined by the sp package, the exception being the USAbondaries package which generates simple feature (sf) objects. In both cases you can convert these into a data frame with `fortify()`:
 
 ```{r}
 library(USAboundaries)
 c18 <- us_boundaries(as.Date("1820-01-01"))
 c18df <- fortify(c18)
-head(c18df)
 
-ggplot(c18df, aes(long, lat)) + 
-  geom_polygon(aes(group = group), colour = "grey50", fill = NA) +
-  coord_quickmap()
+ggplot(c18df, aes(geometry = geometry)) + 
+  geom_sf()
 ```
 
 ### Point metadata


### PR DESCRIPTION
With the most recent version of the USAboundaries package (0.3.0) the code chunk in lines 683-690 was failing so I updated it to work with the newest version, using geom_sf(). I also removed the head(c18df) function call, as the c18df object is now 19 columns wide, which made the print aesthetically displeasing. In addition I changed the description (line 681) to accomodate this change.