### PR TITLE
install USAboundariesData from GitHub

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,4 +37,6 @@ Imports:
   USAboundariesData,
   wesanderson,
   xtable
+Remotes:
+  ropensci/USAboundariesData
 SystemRequirements: pandoc (>= 2.3.1) - https://pandoc.org/


### PR DESCRIPTION
USAboundariesData is not available in CRAN (at least for R 3.6.1)

```
> install.packages("USAboundariesData")
Installing package into ‘/home/zhuoer/.local/lib/R’
(as ‘lib’ is unspecified)
Warning message:
package ‘USAboundariesData’ is not available (for R version 3.6.1) 
```

As djnavarro adds (76297b68c6ccc66c87bc30dc7d9a920f73629084) `http://packages.ropensci.org` to `repos`  for Travis, the `DESCRIPTION` file also needs to change when `remotes::install_github("hadley/ggplot2-book")`.
