### PR TITLE
save plot object to disk should not rely on `last_plot()`

### DIFF
--- a/getting-started.Rmd
+++ b/getting-started.Rmd
@@ -514,7 +514,7 @@ Once you have a plot object, there are a few things you can do with it:
   
     ```{r, eval = FALSE}
     # Save png to disk
-    ggsave("plot.png", width = 5, height = 5)
+    ggsave("plot.png", p, width = 5, height = 5)
     ```
 
   * Briefly describe its structure with `summary()`. \indexf{summary}


### PR DESCRIPTION
"Getting started > Output" mainly talks about the plot obecjt, so we should supply it _explicitly_ to `ggsave()`.