### PR TITLE
underscore in fig.cap not supported well for PDF

### DIFF
--- a/facet.Rmd
+++ b/facet.Rmd
@@ -17,7 +17,8 @@ There are three types of facetting:
 
 The differences between `facet_wrap()` and `facet_grid()` are illustrated in Figure \@ref(fig:facet-sketch).
 
-```{r facet-sketch, echo = FALSE, out.width = "75%", fig.cap="A sketch illustrating the difference between the two facetting systems. `facet_grid()` (left) is fundamentally 2d, being made up of two independent components. `facet_wrap()` (right) is 1d, but wrapped into 2d to save space."}
+(ref:facet-sketch-caption) A sketch illustrating the difference between the two facetting systems. `facet_grid()` (left) is fundamentally 2d, being made up of two independent components. `facet_wrap()` (right) is 1d, but wrapped into 2d to save space.
+```{r facet-sketch, echo = FALSE, out.width = "75%", fig.cap="(ref:facet-sketch-caption)"}
 knitr::include_graphics("diagrams/position-facets.png", dpi = 300, auto_pdf = TRUE)
 ```
 


### PR DESCRIPTION
Fix by adding a ref, else there will be a Missing $ inserted error when targeting PDF.

The solution from rstudio/bookdown#209