### PR TITLE
disables crayon

### DIFF
--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -13,6 +13,8 @@ jobs:
 
       - name: Setup R
         uses: r-lib/actions/setup-r@master
+        with:
+          crayon.enabled: 'FALSE'
 
       - name: Install tinytex
         uses: r-lib/actions/setup-tinytex@master


### PR DESCRIPTION
- should fix #185 
- possibly relevant to #186 (because crayon produces unreadable characters in search.json)