### PR TITLE
Proposed change to scales toolbox structure

### DIFF
--- a/scales-colour.Rmd
+++ b/scales-colour.Rmd
@@ -180,6 +180,23 @@ leg + scale_fill_continuous(breaks = NULL)
 ```
 
 
+### Transformations
+
+Although the most common use for transformations is to adjust position scales, they can sometimes be helpful to when applied to other aesthetics. Often this is purely a matter of visual emphasis. An example of this for the Old Faithful density plot is shown below. The linearly mapped scale on the left makes it easy to see the peaks of the distribution, whereas the transformed representation on the right makes it easier to see the regions of non-negligible density around those peaks:
+
+`r columns(2, 2/3)`
+```{r}
+base <- ggplot(faithfuld, aes(waiting, eruptions)) + 
+  geom_raster(aes(fill = density)) + 
+  scale_x_continuous(NULL, NULL, expand = c(0, 0)) +
+  scale_y_continuous(NULL, NULL, expand = c(0, 0))
+  
+base
+base + scale_fill_continuous(trans = "sqrt")
+```
+
+This technique should be used with care.
+
 ## Discrete colour scales {#colour-discrete}
 
 Discrete colour and fill scales occur in many situations. A typical example is a barchart that encodes both position and fill to the same variable. Many concepts from Section \@ref(colour-continuous) apply to discrete scales, which I will illustrate using this barchart as the running example: \index{Colour!discrete scales}
@@ -380,6 +397,64 @@ Note that like the discrete `scale_fill_brewer()`---and unlike the continuous `s
 ## Alpha scales
 
 Alpha scales map the transparency of a shade to a value in the data. They are not often useful, but can be a convenient way to visually down-weight less important observations. `scale_alpha()` is an alias for `scale_alpha_continuous()` since that is the most common use of alpha, and it saves a bit of typing.
+
+
+
+## Scale names
+
+A common task when creating plots is to customise the title of the axes and legends. To illustrate how this is done, I'll create a small  `toy` data frame that I will reuse throughout the chapter:
+    
+```{r}
+toy <- data.frame(
+  const = 1, 
+  up = 1:4,
+  txt = letters[1:4], 
+  big = (1:4)*1000,
+  log = c(2, 5, 10, 2000)
+)
+toy
+```
+
+The axis or legend title is specified by `name`, which is always the first argument to the scale function. Usually this argument takes a text string as input, using `\n` to specify line breaks, but you can supply mathematical expressions wrapped `quote()`, as described in `?plotmath`
+\index{Axis!title} \index{Legend!title}
+    
+`r columns(2, 1 / 2)`
+```{r guide-names}
+base <- ggplot(toy, aes(up, up)) + geom_point()
+
+base + scale_x_continuous("X axis")
+base + scale_x_continuous(quote(a + mathematical ^ expression))
+```
+
+It is also possible to include (some) markdown in axis and legend titles with the help of the ggtext package [@ggtext] and the ggplot2 theme system (see Chapter \@ref(polishing)). To enable markdown you need to set the relevant theme element to `ggtext::element_markdown()`, as demonstrated below:
+
+`r columns(2, 1 / 2)`
+```{r markdown-with-ggtext}
+base <- ggplot(toy, aes(up, up)) + 
+  geom_point() + 
+  scale_x_continuous("Axis title with *italics* and **boldface**")
+
+base
+base + theme(axis.title.x = ggtext::element_markdown())
+```
+
+Because tweaking axis and legend labels is such a common task, ggplot2 provides the `labs()` helper function that saves you some typing. It allows you to set the name for one or more scales, using name-value pairs like `x = "X axis"` or `fill = "fill legend"`. It also allows you to specify other plot labels, like titles, subtitles, captions and tags (see Section \@ref(titles)):
+
+`r columns(2, 2/3)`
+```{r guide-names-helper}
+ggplot(toy, aes(const, up)) + 
+  geom_point(aes(colour = txt)) + 
+  labs(
+    x = "X axis", 
+    y = quote(Y^axis), 
+    colour = "Colour\nlegend",
+    title = "A pithy title",
+    subtitle = "A more precise subtitle"
+  )
+```
+
+There are two ways to remove the axis label. Setting `labs(x = "")` omits the label but still allocates space; setting `labs(x = NULL)` removes the label and its space. 
+
 
 ## Legends
 

--- a/scales-other.Rmd
+++ b/scales-other.Rmd
@@ -3,7 +3,7 @@ source("common.R")
 columns(1, 2 / 3)
 ```
 
-# Other aesthetics
+# Other aesthetics {#scale-other}
 
 ## Size
 \index{Size}

--- a/scales-position.Rmd
+++ b/scales-position.Rmd
@@ -17,6 +17,63 @@ ggplot(mpg, aes(x = displ, y = after_stat(count))) + geom_histogram()
 
 Although the first example does not state the y-aesthetic mapping explicitly, it still exists and is associated with (in this case) a continuous position scale.
 
+
+## Scale names {#scale-name}
+
+A common task when creating plots is to customise the title of the axes and legends. To illustrate how this is done, I'll create a small  `toy` data frame that I will reuse throughout the chapter:
+    
+```{r}
+toy <- data.frame(
+  const = 1, 
+  up = 1:4,
+  txt = letters[1:4], 
+  big = (1:4)*1000,
+  log = c(2, 5, 10, 2000)
+)
+toy
+```
+
+The axis or legend title is specified by `name`, which is always the first argument to the scale function. Usually this argument takes a text string as input, using `\n` to specify line breaks, but you can supply mathematical expressions wrapped `quote()`, as described in `?plotmath`
+\index{Axis!title} \index{Legend!title}
+    
+`r columns(2, 1 / 2)`
+```{r guide-names}
+base <- ggplot(toy, aes(up, up)) + geom_point()
+
+base + scale_x_continuous("X axis")
+base + scale_x_continuous(quote(a + mathematical ^ expression))
+```
+
+It is also possible to include (some) markdown in axis and legend titles with the help of the ggtext package [@ggtext] and the ggplot2 theme system (see Chapter \@ref(polishing)). To enable markdown you need to set the relevant theme element to `ggtext::element_markdown()`, as demonstrated below:
+
+`r columns(2, 1 / 2)`
+```{r markdown-with-ggtext}
+base <- ggplot(toy, aes(up, up)) + 
+  geom_point() + 
+  scale_x_continuous("Axis title with *italics* and **boldface**")
+
+base
+base + theme(axis.title.x = ggtext::element_markdown())
+```
+
+Because tweaking axis and legend labels is such a common task, ggplot2 provides the `labs()` helper function that saves you some typing. It allows you to set the name for one or more scales, using name-value pairs like `x = "X axis"` or `fill = "fill legend"`. It also allows you to specify other plot labels, like titles, subtitles, captions and tags (see Section \@ref(titles)):
+
+`r columns(2, 2/3)`
+```{r guide-names-helper}
+ggplot(toy, aes(const, up)) + 
+  geom_point(aes(colour = txt)) + 
+  labs(
+    x = "X axis", 
+    y = quote(Y^axis), 
+    colour = "Colour\nlegend",
+    title = "A pithy title",
+    subtitle = "A more precise subtitle"
+  )
+```
+
+There are two ways to remove the axis label. Setting `labs(x = "")` omits the label but still allocates space; setting `labs(x = NULL)` removes the label and its space. 
+
+
 \index{Scales!position} \index{Positioning!scales} 
 
 ## Numeric
@@ -36,6 +93,59 @@ For more information on scale transformations see Section \@ref(scale-transforma
 \indexf{scale\_x\_continuous} 
 
 ### Limits
+
+
+
+### Transformation {#scale-transformation}
+
+When working with numeric data, the default is to map linearly from the data space onto the aesthetic space. It is possible to override this default using transformations. Every continuous scale takes a `trans` argument, allowing the use of a variety of transformations:
+\index{Scales!position} \index{Transformation!scales} \index{Log!scale} \indexf{scale\_x\_log10}
+
+`r columns(2, 1)`
+```{r}
+# convert from fuel economy to fuel consumption
+ggplot(mpg, aes(displ, hwy)) + 
+  geom_point() + 
+  scale_y_continuous(trans = "reciprocal")
+
+# log transform x and y axes
+ggplot(diamonds, aes(price, carat)) + 
+  geom_bin2d() + 
+  scale_x_continuous(trans = "log10") +
+  scale_y_continuous(trans = "log10")
+```
+
+The transformation is carried out by a "transformer", which describes the transformation, its inverse, and how to draw the labels. You can construct your own transformer using `scales::trans_new()`, but --- as the plots above illustrate --- ggplot2 understands many common transformations supplied by the scales package. The following table lists the most common variants: 
+
+| Name      | Function $f(x)$         | Inverse $f^{-1}(y)$
+|-----------|-------------------------|------------------------
+| asn       | $\tanh^{-1}(x)$         | $\tanh(y)$
+| exp       | $e ^ x$                 | $\log(y)$
+| identity  | $x$                     | $y$
+| log       | $\log(x)$               | $e ^ y$
+| log10     | $\log_{10}(x)$          | $10 ^ y$
+| log2      | $\log_2(x)$             | $2 ^ y$
+| logit     | $\log(\frac{x}{1 - x})$ | $\frac{1}{1 + e(y)}$
+| pow10     | $10^x$                  | $\log_{10}(y)$
+| probit    | $\Phi(x)$               | $\Phi^{-1}(y)$
+| reciprocal| $x^{-1}$                | $y^{-1}$
+| reverse   | $-x$                    | $-y$
+| sqrt      | $x^{1/2}$               | $y ^ 2$
+
+To simplify matters, ggplot2 provides convenience functions for the most common transformations: `scale_x_log10()`, `scale_x_sqrt()` and `scale_x_reverse()` provide the relevant transformation on the x axis, with similar functions provided for the y axis. Thus code below produces the same two plots shown in the previous example:
+
+```{r, fig.show="hide"}
+ggplot(mpg, aes(displ, hwy)) + 
+  geom_point() +
+  scale_y_reverse()
+
+ggplot(diamonds, aes(price, carat)) + 
+  geom_bin2d() + 
+  scale_x_log10() +
+  scale_y_log10()
+```
+
+Note that there is nothing preventing you from performing these transformations manually. For example, instead of using `scale_x_log10()` to transform the scale, you could transform the data instead and plot `log10(x)`. The appearance of the geom will be the same, but the tick labels will be different. Specifically, if you use a transformed scale, the axes will be labelled in the original data space; if you transform the data, the axes will be labelled in the transformed space. Regardless of which method you use, the transformation occurs before any statistical summaries. To transform _after_ statistical computation use `coord_trans()`. See Section \@ref(cartesian) for more details.
 
 
 ### Out of bounds values {#oob}

--- a/scales.Rmd
+++ b/scales.Rmd
@@ -13,64 +13,73 @@ Scales in ggplot2 control the mapping from data to aesthetics. They take your da
 
 In ggplot2, guides are produced automatically based on the layers in your plot. You don't directly control the legends and axes; instead you set up the data so that there's a clear mapping between data and aesthetics, and a guide is generated for you. This is very different to base R graphics, where you have total control over the legend, and can be frustrating when you first start using ggplot2. However, once you get the hang of it, you'll find that it saves you time, and there is little you cannot do.
 
-Divide scales into three main groups:
+Scales serve two related roles. First, they construct a mapping from a region in the data space to a region in the aesthetic space (i.e., positions, colours, etc). Second, they govern the axis and legend of the plot, the visual guides that tell the reader how to interpret the observable features of the plot. You might find it surprising that axes and legends are the same type of thing, but while they look very different they have the same purpose: to allow you to read observations from the plot and map them back to their original values. 
 
-* Position scales and axes.
-* Colour scales and legends.
-* Other scales for non-position aesthetics.
+| Argument name   | Axis              | Legend        
+|:----------------|:------------------|:--------------
+| `name`          | Label             | Title         
+| `breaks`        | Ticks & grid line | Key           
+| `labels`        | Tick label        | Key label     
 
-## Scale names {#scale-name}
-
-A common task when creating plots is to customise the title of the axes and legends. To illustrate how this is done, I'll create a small  `toy` data frame that I will reuse throughout the chapter:
-    
-```{r}
-toy <- data.frame(
-  const = 1, 
-  up = 1:4,
-  txt = letters[1:4], 
-  big = (1:4)*1000,
-  log = c(2, 5, 10, 2000)
-)
-toy
+```{r guides, echo = FALSE, out.width = "100%", fig.cap = "Common components of axes and legends"}
+knitr::include_graphics("diagrams/scale-guides.png", dpi = 300, auto_pdf = TRUE)
 ```
 
-The axis or legend title is specified by `name`, which is always the first argument to the scale function. Usually this argument takes a text string as input, using `\n` to specify line breaks, but you can supply mathematical expressions wrapped `quote()`, as described in `?plotmath`
-\index{Axis!title} \index{Legend!title}
-    
-`r columns(2, 1 / 2)`
-```{r guide-names}
-base <- ggplot(toy, aes(up, up)) + geom_point()
 
-base + scale_x_continuous("X axis")
-base + scale_x_continuous(quote(a + mathematical ^ expression))
+Every aesthetic in your plot is associated with exactly one scale. For instance, when you write:
+
+```{r default-scales, fig.show = "hide"}
+ggplot(mpg, aes(displ, hwy)) + 
+  geom_point(aes(colour = class))
 ```
 
-It is also possible to include (some) markdown in axis and legend titles with the help of the ggtext package [@ggtext] and the ggplot2 theme system (see Chapter \@ref(polishing)). To enable markdown you need to set the relevant theme element to `ggtext::element_markdown()`, as demonstrated below:
+ggplot2 adds a default scale for each aesthetic used in the plot: 
 
-`r columns(2, 1 / 2)`
-```{r markdown-with-ggtext}
-base <- ggplot(toy, aes(up, up)) + 
-  geom_point() + 
-  scale_x_continuous("Axis title with *italics* and **boldface**")
-
-base
-base + theme(axis.title.x = ggtext::element_markdown())
+```{r, fig.show = "hide"}
+ggplot(mpg, aes(displ, hwy)) + 
+  geom_point(aes(colour = class)) +
+  scale_x_continuous() + 
+  scale_y_continuous() + 
+  scale_colour_discrete()
 ```
 
-Because tweaking axis and legend labels is such a common task, ggplot2 provides the `labs()` helper function that saves you some typing. It allows you to set the name for one or more scales, using name-value pairs like `x = "X axis"` or `fill = "fill legend"`. It also allows you to specify other plot labels, like titles, subtitles, captions and tags (see Section \@ref(titles)):
+The choice of default scale depends on the aesthetic and the variable type. In this example `hwy` is a continuous variable mapped to the y aesthetic so the default scale is `scale_y_continuous()`; similarly `class` is discrete so when mapped to the colour aesthetic the default scale becomes `scale_colour_discrete()`. 
 
-`r columns(2, 2/3)`
-```{r guide-names-helper}
-ggplot(toy, aes(const, up)) + 
-  geom_point(aes(colour = txt)) + 
-  labs(
-    x = "X axis", 
-    y = quote(Y^axis), 
-    colour = "Colour\nlegend",
-    title = "A pithy title",
-    subtitle = "A more precise subtitle"
-  )
+Specifying these defaults would be tedious so ggplot2 does it for you. But if you want to override the default scales, you'll need to add the scale yourself, like this: \index{Scales!defaults}
+
+```{r, fig.show = "hide"}
+ggplot(mpg, aes(displ, hwy)) + 
+  geom_point(aes(colour = class)) +
+  scale_x_sqrt() + 
+  scale_colour_brewer()
 ```
 
-There are two ways to remove the axis label. Setting `labs(x = "")` omits the label but still allocates space; setting `labs(x = NULL)` removes the label and its space. 
+Here `scale_x_sqrt()` modifies the scale associated with the x axis, and `scale_colour_brewer()` does the same for colour. Because the role of the scale functions is to modify scales, the use of `+` to "add" scales to a plot can be a little misleading: when you `+` a scale, you're not actually adding it to the plot, but overriding the existing scale. If you supply two scales for the same aesthetic, the last scale takes precedence. This means that the following two specifications are equivalent: \indexc{+} 
+
+```{r multiple-scales, fig.show = "hide"}
+ggplot(mpg, aes(displ, hwy)) + 
+  geom_point(aes(colour = class)) +
+  scale_colour_viridis_d() +
+  scale_colour_brewer()
+
+ggplot(mpg, aes(displ, hwy)) + 
+  geom_point(aes(colour = class)) +
+  scale_colour_brewer()
+```
+
+Note the message when you add multiple scales for the same aesthetic, which makes it harder to accidentally overwrite an existing scale. If you see this in your own code, you should make sure that you're only adding one scale to each aesthetic.
+
+The scale functions follow a common naming scheme. You've probably already figured out the scheme, but to be concrete, it's made up of three pieces separated by "_":
+
+1. `scale`
+1. The name of the primary aesthetic (e.g., `colour`, `shape` or `x`)
+1. The name of the scale (e.g., `continuous`, `discrete`, `brewer`).
+
+Scales work similarly for all aesthetics, but there are enough differences that it helps to divide them into three groups and cover each group in a separate chapter: 
+
+* Position scales and axes are covered in Chapter \@ref(scale-position)
+* Colour scales and legends are covered in Chapter \@ref(scale-colour)
+* Other scales for non-position aesthetics are covered in Chapter \@ref(scale-other)
+
+
 


### PR DESCRIPTION
It feels weird to have "names" be the only practical section in the theory chapter. At the risk of partial duplication I'd rather cover `labs()` in the position chapter and the colour chapters. That way the unnumbered intro chapter is solely concerned with theory and each of the other three becomes more self-contained. This PR:

- restores the "scale transformation" content that seems to have gotten lost
- restores some of the old "theory" sections to the intro chapter (it needs reworking though)
- places copies of the scale names section in position and colour chapters (to be edited later)

From there I'm hoping I should be able to edit each chapter independently, in separate PRs. If that sounds sensible to you I'll merge this one into master and then branch from there. 