### PR TITLE
Remove left-in writing note

### DIFF
--- a/scales-guides.Rmd
+++ b/scales-guides.Rmd
@@ -7,8 +7,6 @@ columns(1, 2 / 3)
 
 Formally, each scale is a function from a region in data space (the domain of the scale) to a region in aesthetic space (the range of the scale). The axis or legend is the inverse function: it allows you to convert visual properties back to data. 
 
-Needs to emphasise orthogonality of various components, and show how things that we showed just for position or colour scales also apply elsewhere.
-
 ## Scale specification {#scale-usage}
 
 An important property of ggplot2 is the principle that every aesthetic in your plot is associated with exactly one scale. For instance, when you write:


### PR DESCRIPTION
The second paragraph in "15 Scales and Guides" reads

>Needs to emphasise orthogonality of various components, and show how things that we showed just for position or colour scales also apply elsewhere.

...which seems like it's a leftover note about writing the chapter? This PR removes it.