### PR TITLE
Remove references to Shiny apps

### DIFF
--- a/introduction.Rmd
+++ b/introduction.Rmd
@@ -157,8 +157,8 @@ Before we continue, make sure you have all the software you need for this book:
     If you'd like to learn how to use R, I'd recommend my [*R for Data Science*](https://r4ds.had.co.nz/) which is designed to get you up and running with R with a minimum of fuss.
 
 -   **RStudio**: RStudio is a free and open source integrated development environment (IDE) for R.
-    While you can write and use Shiny apps with any R environment (including R GUI and [ESS](http://ess.r-project.org)), RStudio has some nice features specifically for authoring, debugging, and deploying Shiny apps.
-    We recommend giving it a try, but it's not required to be successful with Shiny or with this book.
+    While you can write and use R code with any R environment (including R GUI and [ESS](http://ess.r-project.org)), RStudio has some nice features specifically for authoring and debugging your code.
+    We recommend giving it a try, but it's not required to be successful with ggplot2 or with this book.
     You can download RStudio Desktop from <https://www.rstudio.com/products/rstudio/download>
 
 -   **R packages**: This book uses a bunch of R packages.


### PR DESCRIPTION
The book isn't about Shiny, so there's no need to explain how RStudio makes developing Shiny apps easier.