### PR TITLE
Fix missing Hmisc dependency for plots using `ggplot2::mean_cl_normal()`

### DIFF
--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -28,6 +28,8 @@ jobs:
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v1
+        with:
+          extra-packages: Hmisc
 
       - name: Cache bookdown results
         uses: actions/cache@v2


### PR DESCRIPTION
Fixes https://github.com/hadley/ggplot2-book/issues/276