### PR TITLE
typo b ~ a

### DIFF
--- a/facet.Rmd
+++ b/facet.Rmd
@@ -71,7 +71,7 @@ base + facet_wrap(~class, nrow = 3, dir = "v")
     base + facet_grid(drv ~ .)
     ```
 
-*   `a ~ b` spreads `a` across columns and `b` down rows. You'll usually 
+*   `b ~ a` spreads `a` across columns and `b` down rows. You'll usually 
     want to put the variable with the greatest number of levels in the columns, 
     to take advantage of the aspect ratio of your screen.
 


### PR DESCRIPTION
Minor typo. 

Should be `b ~ a` instead of `a ~ b` to be both correct and consistent with the previous two bullets use of `. ~ a` and `b ~ .`