### PR TITLE
Example in plot environment is not true

### DIFF
--- a/programming.Rmd
+++ b/programming.Rmd
@@ -312,16 +312,18 @@ There's another advantage to `aes_()` over `aes()` if you're writing ggplot2 plo
 
 ### The plot environment
 
-As you create more sophisticated plotting functions, you'll need to understand a bit more about ggplot2's scoping rules. ggplot2 was written well before I understood the full intricacies of non-standard evaluation, so it has a rather simple scoping system. If a variable is not found in the `data`, it is looked for in _the_ plot environment. There is only one environment for a plot (not one for each layer), and it is the environment in which `ggplot()` is called from (i.e. the `parent.frame()`). \index{Environments} \indexf{parent.frame}
+As you create more sophisticated plotting functions, you'll need to understand a bit more about ggplot2's scoping rules. ggplot2 was written well before I understood the full intricacies of non-standard evaluation, so it has a rather simple scoping system. If a variable is not found in the `data` and the mapping formula environment, it is looked for in _the_ plot environment. There is only one environment for a plot (not one for each layer), and it is the environment in which `ggplot()` is called from (i.e. the `parent.frame()`). \index{Environments} \indexf{parent.frame}
 
 This means that the following function won't work because `n` is not stored in an environment accessible when the expressions in `aes()` are evaluated. 
 
 ```{r, error = TRUE, fig.show = "hide"}
+map <- function() {
+  aes(x = x / n)
+}
 f <- function() {
   n <- 10
-  geom_line(aes(x / n)) 
+  geom_line(map())
 }
-df <- data.frame(x = 1:3, y = 1:3)
 ggplot(df, aes(x, y)) + f()
 ```
 


### PR DESCRIPTION
The original example shown below isn't illustrative of the statement preceding it because it does work (formula in aes captures the function environment). The suggested edit includes an example where it would cause an error. 

```
f <- function() {
  n <- 10
  geom_line(aes(x = x/n))
}
ggplot(df, aes(x, y)) + f()
```