### PR TITLE
Update text to match the coordinates in one figure

### DIFF
--- a/annotations.Rmd
+++ b/annotations.Rmd
@@ -118,8 +118,8 @@ annotation can be tricky due to the way that R handles fonts. The ggplot2 packag
       x = c(1, 1, 2, 2, 1.5),
       y = c(1, 2, 1, 2, 1.5),
       text = c(
-        "bottom-left", "bottom-right", 
-        "top-left", "top-right", "center"
+        "bottom-left", "top-left", 
+        "bottom-right", "top-right", "center"
       )
     )
     ggplot(df, aes(x, y)) +


### PR DESCRIPTION
Text and location did not match. Updated the code by switching "bottom-right" and "top-left".