### PR TITLE
Fixing broken links in "Exercises" section

### DIFF
--- a/mastery.Rmd
+++ b/mastery.Rmd
@@ -243,7 +243,7 @@ There is also another thing that turns out to be sufficiently useful that we sho
         Joe Ward, and Matthew Ericson at The New York Times. 
         <http://nyti.ms/1duzTvY>
     
-    1.  "London Cycle Hire Journeys", by James Cheshire. <http://bit.ly/1S2cyRy>
+    1.  "London Cycle Hire Journeys", by James Cheshire. <https://jcheshire.com/wp-content/uploads/2012/02/bike_pollution_web.png>
     
     1.  The Pew Research Center's favorite data visualizations of 2014:
         <http://pewrsr.ch/1KZSSN6>
@@ -254,7 +254,7 @@ There is also another thing that turns out to be sufficiently useful that we sho
     1. "In Climbing Income Ladder, Location Matters" by the Mike Bostock, 
         Shan Carter, Amanda Cox, Matthew Ericson, Josh Keller, Alicia 
         Parlapiano, Kevin Quealy and Josh Williams at the New York Times:
-        <http://nyti.ms/1S2dJQT>
+        <http://multimedia.jmc.uiowa.edu/mmkreamer/files/2014/04/Screen-Shot-2014-04-30-at-6.54.23-PM.png>
         
     1. "Dissecting a Trailer: The Parts of the Film That Make the Cut",
         by Shan Carter, Amanda Cox, and Mike Bostock at the New York Times:


### PR DESCRIPTION
Graphics for (1) "London Cycle Hire Journeys" and (2) "In Climbing Income Ladder, Location Matters" were inaccessible.

(1) - Original link was broken. I've replaced for another one hosted in James's own blog but that is still online.
(2) - Original link is payawalled. I've replaced for a link pointing to a blog that has a post analysing this graphic. I've pointed directly to the graphic itself because pointing to the blogpost would spoil the exercise.