### PR TITLE
Change ESPG website to new link

### DIFF
--- a/maps.Rmd
+++ b/maps.Rmd
@@ -184,7 +184,7 @@ Taken together, the geodetic datum (e.g, WGS84), the type of map projection (e.g
 st_crs(oz_votes)
 ```
 
-Most of this output corresponds to a **well-known text** (WKT) string that unambiguously describes the CRS. This verbose WKT representation is used by sf internally, but there are several ways to provide user input that sf understands. One such method is to provide numeric input in the form of an **EPSG code** (see <http://www.epsg.org/>). The default CRS in the `oz_votes` data corresponds to EPSG code 4283:
+Most of this output corresponds to a **well-known text** (WKT) string that unambiguously describes the CRS. This verbose WKT representation is used by sf internally, but there are several ways to provide user input that sf understands. One such method is to provide numeric input in the form of an **EPSG code** (see <https://epsg.io/>). The default CRS in the `oz_votes` data corresponds to EPSG code 4283:
 
 ```{r}
 st_crs(oz_votes) == st_crs(4283)


### PR DESCRIPTION
http://www.epsg.org/ page no longer exists (I'm seeing '404 Not Found'). I think https://epsg.io/ might be the replacement.