### PR TITLE
define caption externally for proper LaTeX escaping of underscores

### DIFF
--- a/facet.Rmd
+++ b/facet.Rmd
@@ -17,7 +17,9 @@ There are three types of faceting:
 
 The differences between `facet_wrap()` and `facet_grid()` are illustrated in Figure \@ref(fig:facet-sketch).
 
-```{r facet-sketch, echo = FALSE, out.width = "75%", fig.cap="A sketch illustrating the difference between the two faceting systems. `facet_grid()` (left) is fundamentally 2d, being made up of two independent components. `facet_wrap()` (right) is 1d, but wrapped into 2d to save space."}
+(ref:facet-cap) A sketch illustrating the difference between the two faceting systems. `facet_grid()` (left) is fundamentally 2d, being made up of two independent components. `facet_wrap()` (right) is 1d, but wrapped into 2d to save space.
+
+```{r facet-sketch, echo = FALSE, out.width = "75%", fig.cap='(ref:facet-cap)'}
 knitr::include_graphics("diagrams/position-facets.png", dpi = 300, auto_pdf = TRUE)
 ```
 


### PR DESCRIPTION
Fixes #319.

Define the figure 17.1 caption outside the rmarkdown block so that the underscores in the function names within the caption are properly escaped for LaTeX when rendering to PDF. Does not affect HTML output.