### PR TITLE
Fix left quotation marks not rendering in text

### DIFF
--- a/mastery.Rmd
+++ b/mastery.Rmd
@@ -53,7 +53,7 @@ ggplot(mpg, aes(displ, hwy, colour = factor(cyl))) +
 
 In ggplot, we can produce many plots that don't make sense, yet are grammatically valid. This is no different than English, where we can create senseless but grammatical sentences like the angry rock barked like a comma.
 
-Points, lines and bars are all examples of geometric objects, or **geoms**. Geoms determine the ``type'' of the plot. Plots that use a single geom are often given a special name: 
+Points, lines and bars are all examples of geometric objects, or **geoms**. Geoms determine the "type" of the plot. Plots that use a single geom are often given a special name: 
 
 |Named plot           |Geom    |Other features            |
 |:--------------------|:-------|:-------------------------|


### PR DESCRIPTION
Before: Missing left quotation marks
<img width="723" alt="Screen Shot 2022-09-23 at 10 32 27 AM" src="https://user-images.githubusercontent.com/9222156/192029166-8f4ba32d-2e27-495e-8748-859c91356986.png">

After:
<img width="677" alt="Screen Shot 2022-09-23 at 10 31 46 AM" src="https://user-images.githubusercontent.com/9222156/192029153-d0a891d0-9209-454f-8480-88ad7dbc6749.png">