### PR TITLE
Fix minor plain text

### DIFF
--- a/collective-geoms.Rmd
+++ b/collective-geoms.Rmd
@@ -90,7 +90,7 @@ In ggplot2, this is handled differently for different collective geoms. Lines an
 
 `r columns(2, 2 / 3)`
 ```{r}
-df <- data.frame(x = 1:3, y = 1:3, colour = c(1,3,5))
+df <- data.frame(x = 1:3, y = 1:3, colour = c(1, 3, 5))
 
 ggplot(df, aes(x, y, colour = factor(colour))) + 
   geom_line(aes(group = 1), size = 2) +

--- a/layers.Rmd
+++ b/layers.Rmd
@@ -493,8 +493,8 @@ The result of this plot is rather surprising: low quality diamonds seem to be mo
     smoothed <- data.frame(displ = seq(1.6, 7, length = 50))
     pred <- predict(mod, newdata = smoothed, se = TRUE) 
     smoothed$hwy <- pred$fit
-    smoothed$hwy_lwr <- pred$fit - 1.96 * pred$se.fit
-    smoothed$hwy_upr <- pred$fit + 1.96 * pred$se.fit
+    smoothed$hwy_lwr <- pred$fit - (1.96 * pred$se.fit)
+    smoothed$hwy_upr <- pred$fit + (1.96 * pred$se.fit)
     ```
     
 1.  What stats were used to create the following plots?

--- a/maps.Rmd
+++ b/maps.Rmd
@@ -105,7 +105,7 @@ Adding labels to maps is an example of annotating plots (Chapter \@ref(annotatio
 map data for the relevant electorates, and then add the label. The plot below zooms in on the Sydney region by specifying `xlim` and `ylim` in `coord_sf()` and then uses `geom_sf_label()` to overlay each electorate with a label:
 
 ```{r}
-# filter electorates in the Sydney metropolitan region
+# Filter electorates in the Sydney metropolitan region
 sydney_map <- ozmaps::abs_ced %>% filter(NAME %in% c(
   "Sydney", "Wentworth", "Warringah", "Kingsford Smith", "Grayndler", "Lowe", 
   "North Sydney", "Barton", "Bradfield", "Banks", "Blaxland", "Reid", 
@@ -113,7 +113,7 @@ sydney_map <- ozmaps::abs_ced %>% filter(NAME %in% c(
   "Mackellar", "Greenway", "Mitchell", "Chifley", "McMahon"
 ))
 
-# draw the electoral map of Sydney
+# Draw the electoral map of Sydney
 ggplot(sydney_map) + 
   geom_sf(aes(fill = NAME), show.legend = FALSE) + 
   coord_sf(xlim = c(150.97, 151.3), ylim = c(-33.98, -33.79)) + 

--- a/networks.Rmd
+++ b/networks.Rmd
@@ -111,13 +111,13 @@ In order to show the graph above we're using the `geom_edge_link()` and `geom_no
 Some layouts may be used in both a linear and circular version. The correct way to change this in ggplot2 would be to use `coord_polar()` to change the coordinate system, but since we only want to change the position of nodes in the layout, and not affect the edges, this is a function of the layout. The following can show the difference:
 
 ```{r}
-ggraph(luv_graph, layout = 'dendrogram', circular = TRUE) + 
+ggraph(luv_graph, layout = "dendrogram", circular = TRUE) + 
   geom_edge_link() + 
   coord_fixed()
 ```
 
 ```{r}
-ggraph(luv_graph, layout = 'dendrogram') + 
+ggraph(luv_graph, layout = "dendrogram") + 
   geom_edge_link() + 
   coord_polar() + 
   scale_y_reverse()

--- a/scales-position.Rmd
+++ b/scales-position.Rmd
@@ -126,17 +126,17 @@ Axis expansions are described in terms of an "additive" factor, which specifies 
 
 `r columns(3, 1, 1)`
 ```{r}
-# additive expansion of three units on both axes
+# Additive expansion of three units on both axes
 base + 
   scale_x_continuous(expand = expansion(add = 3)) + 
   scale_y_continuous(expand = expansion(add = 3))
 
-# multiplicative expansion of 20% on both axes
+# Multiplicative expansion of 20% on both axes
 base + 
   scale_x_continuous(expand = expansion(mult = .2)) + 
   scale_y_continuous(expand = expansion(mult = .2)) 
 
-# multiplicative expansion of 5% at the lower end of each axes,
+# Multiplicative expansion of 5% at the lower end of each axes,
 # and 20% at the upper end; for the y-axis the expansion is 
 # set directly instead of using expansion()
 base + 


### PR DESCRIPTION
- It fixes capitalizations in comments.
- It also fixes spacing in the code and improves readability of arithmetic operation's order.