### PR TITLE
Change `rstudio.com` to `posit.co`

### DIFF
--- a/annotations.Rmd
+++ b/annotations.Rmd
@@ -28,7 +28,7 @@ ggplot(mpg, aes(displ, hwy)) +
     y = "Highway miles per gallon", 
     colour = "Number of cylinders",
     title = "Mileage by engine size and cylinders",
-    subtitle = "Source: http://fueleconomy.gov"
+    subtitle = "Source: https://fueleconomy.gov"
   )
 ```
 

--- a/arranging-plots.Rmd
+++ b/arranging-plots.Rmd
@@ -200,7 +200,7 @@ p12 & theme_bw()
 And auto tagging works as expected as well:
 
 ```{r}
-p12 + plot_annotation(tag_levels = 'A')
+p12 + plot_annotation(tag_levels = "A")
 ```
 
 ## Wrapping up

--- a/ext-springs.Rmd
+++ b/ext-springs.Rmd
@@ -321,7 +321,7 @@ We can test it out by drawing our springs with dots:
 ggplot(some_data) + 
   stat_spring(
     aes(x, y, xend = xend, yend = yend, colour = class),
-    geom = 'point', 
+    geom = "point", 
     n = 15
   ) + 
   facet_wrap(~ class)

--- a/introduction.Rmd
+++ b/introduction.Rmd
@@ -159,7 +159,7 @@ Before we continue, make sure you have all the software you need for this book:
 -   **RStudio**: RStudio is a free and open source integrated development environment (IDE) for R.
     While you can write and use R code with any R environment (including R GUI and [ESS](http://ess.r-project.org)), RStudio has some nice features specifically for authoring and debugging your code.
     We recommend giving it a try, but it's not required to be successful with ggplot2 or with this book.
-    You can download RStudio Desktop from <https://www.rstudio.com/products/rstudio/download>
+    You can download RStudio Desktop from <https://posit.co/download/rstudio-desktop>
 
 -   **R packages**: This book uses a bunch of R packages.
     You can install them all at once by running:
@@ -190,20 +190,20 @@ The advantage of the online documentation is that you can see all the example pl
 
 If you use ggplot2 regularly, it's a good idea to sign up for the ggplot2 mailing list, <http://groups.google.com/group/ggplot2>.
 The list has relatively low traffic and is very friendly to new users.
-Another useful resource is stackoverflow, <http://stackoverflow.com>.
+Another useful resource is stackoverflow, <https://stackoverflow.com>.
 There is an active ggplot2 community on stackoverflow, and many common questions have already been asked and answered.
 In either place, you're much more likely to get help if you create a minimal reproducible example.
 The [reprex](https://github.com/jennybc/reprex) package by Jenny Bryan provides a convenient way to do this, and also include advice on creating a good example.
 The more information you provide, the easier it is for the community to help you.
 
-The number of functions in ggplot2 can be overwhelming, but RStudio provides some great cheatsheets to jog your memory at <http://www.rstudio.com/resources/cheatsheets/>.
+The number of functions in ggplot2 can be overwhelming, but RStudio provides some great cheatsheets to jog your memory at <https://posit.co/resources/cheatsheets/>.
 
 Finally, the complete source code for the book is available online at <https://github.com/hadley/ggplot2-book>.
 This contains the complete text for the book, as well as all the code and data needed to recreate all the plots.
 
 ## Colophon
 
-This book was written in [RStudio](http://www.rstudio.com/ide/) using [bookdown](http://bookdown.org/).
+This book was written in [RStudio](https://posit.co/products/open-source/rstudio/) using [bookdown](http://bookdown.org/).
 The [website](http://ggplot2-book.org/) is hosted with [netlify](http://netlify.com/), and automatically updated after every commit by [Github Actions](https://github.com/features/actions).
 The complete source is available from [GitHub](https://github.com/hadley/ggplot2-book).
 

--- a/layers.Rmd
+++ b/layers.Rmd
@@ -372,7 +372,7 @@ If alternative parameterisations are available, picking the right one for your d
 ### Exercises
 
 1.  Download and print out the ggplot2 cheatsheet from 
-    <http://www.rstudio.com/resources/cheatsheets/> so you have a handy visual
+    <https://posit.co/resources/cheatsheets/> so you have a handy visual
     reference for all the geoms.
     
 1.  Look at the documentation for the graphical primitive geoms. Which

--- a/maps.Rmd
+++ b/maps.Rmd
@@ -405,10 +405,10 @@ though some care would be required to ensure the text is positioned nicely (see 
 
 * The tigris package, <https://github.com/walkerke/tigris>, makes it easy to access the US Census TIGRIS shapefiles [@tigris]. It contains state, county, zipcode, and census tract boundaries, as well as many other useful datasets.
 
-* The rnaturalearth package [@rnaturalearth] bundles up the free, high-quality data from <http://naturalearthdata.com/>. It contains country borders, and borders for the top-level region within each country (e.g. states in the USA, regions in France, counties in the UK).
+* The rnaturalearth package [@rnaturalearth] bundles up the free, high-quality data from <https://naturalearthdata.com/>. It contains country borders, and borders for the top-level region within each country (e.g. states in the USA, regions in France, counties in the UK).
 
-* The osmar package, <https://cran.r-project.org/package=osmar> wraps up the OpenStreetMap API so you can access a wide range of vector data including individual streets and buildings [@osmar]
+* The osmar package, <https://cran.r-project.org/package=osmar> wraps up the OpenStreetMap API so you can access a wide range of vector data including individual streets and buildings [@osmar].
 
-* If you have your own shape files (`.shp`) you can load them into R with `sf::read_sf()`
+* If you have your own shape files (`.shp`) you can load them into R with `sf::read_sf()`.
 
 

--- a/preface-3e.Rmd
+++ b/preface-3e.Rmd
@@ -2,7 +2,7 @@
 
 Welcome to the third edition of "ggplot2: elegant graphics for data analysis".
 I'm so excited to have a new edition of the book updated for all the changes that have happened to ggplot2 in the last five years.
-I'm also excited to finally have an online version of the book, [\<http://ggplot2-book.org/\>](http://ggplot2-book.org/){.uri}, thanks to a renegotiated contract with Springer.
+I'm also excited to finally have an online version of the book, [\<https://ggplot2-book.org/\>](https://ggplot2-book.org/){.uri}, thanks to a renegotiated contract with Springer.
 
 Since the last version of the book, the major change to ggplot2 itself is the growth in the contributor community.
 While I still lead the project and continue to care deeply about visualisation, I'm no longer involved in the day-to-day development of the package.


### PR DESCRIPTION
- It updates `rstudio.com` to `posit.co` for urls.
- It fixes punctuation.
- It changes `http` to `https`, if websites support it.
- It ensures consistency(in favor of `"`) between `"` and `'` in arguments.