### PR TITLE
Fix punctuation of `extensions.qmd` L250

### DIFF
--- a/extensions.qmd
+++ b/extensions.qmd
@@ -247,7 +247,7 @@ By default the top two functions don't do very much, they simply split the data 
 
 Because of this, the only method you usually need to specify as a developer is the `compute_group()` function, whose job is to take the data for a single group and transform it appropriately.
 This will be sufficient to create a working stat, though it may not yield the best performance.
-As a consequence developers sometimes find it valuable to offload some of the work to `compute_panel()` where possible: doing so allows you to vectorise computations and avoid an expensive split-combine step (we'll see an example of this later in @sec-spring-stat) However, as a general rule it is better to begin by modifying `compute_group()` only and see if the performance is adequate.
+As a consequence developers sometimes find it valuable to offload some of the work to `compute_panel()` where possible: doing so allows you to vectorise computations and avoid an expensive split-combine step (we'll see an example of this later in @sec-spring-stat). However, as a general rule it is better to begin by modifying `compute_group()` only and see if the performance is adequate.
 
 To illustrate this, we'll start by creating a stat that calculates the convex hull of a set of points, using the `chull()` function included in `grDevices`.
 As you might expect, most of the work is done by a new ggproto object that we will create:


### PR DESCRIPTION
- It adds a missing punctuation at L250 in the `extensions.qmd` section.