### PR TITLE
Update annotations.qmd to remove presidents with no economic data

### DIFF
--- a/annotations.qmd
+++ b/annotations.qmd
@@ -268,7 +268,7 @@ To do this, we use `geom_rect()` to introduce shading, `geom_vline()` to introdu
 
 ```{r}
 #| label: unemp-pres
-presidential <- subset(presidential, start > economics$date[1])
+presidential <- subset(presidential, start > economics$date[1] & start < economics$date[length(economics$date)])
 
 ggplot(economics) + 
   geom_rect(


### PR DESCRIPTION
I'm assuming that the presidents data was updated at one point and the economics data wasn't. I remember seeing this figure and it didn't include the empty rect at the end. This just adds a check for the last economics date (in addition to the check for first economics date which was already present). 