### PR TITLE
Update scales-colour.qmd

### DIFF
--- a/scales-colour.qmd
+++ b/scales-colour.qmd
@@ -864,9 +864,9 @@ If needed, you can adjust those options independently:
 -   `legend.box.just`: justification of each legend within the overall bounding box, when there are multiple legends ("top", "bottom", "left", or "right").
 
 Alternatively, if there's a lot of blank space in your plot you might want to place the legend inside the plot.
-You can do this by setting `legend.position` to a numeric vector of length two.
+You can do this by setting `legend.position = "inside", legend.position.inside = c(...)` to a numeric vector of length two.
 The numbers represent a relative location in the panel area: `c(0, 1)` is the top-left corner and `c(1, 0)` is the bottom-right corner.
-You control which corner of the legend the `legend.position` refers to with `legend.justification`, which is specified in a similar way.
+You control which corner of the legend the `legend.position.inside` refers to with `legend.justification`, which is specified in a similar way.
 Unfortunately positioning the legend exactly where you want it requires a lot of trial and error.
 
 ```{r}
@@ -878,19 +878,22 @@ base <- ggplot(toy, aes(up, up)) +
 
 base + 
   theme(
-    legend.position = c(0, 1), 
+    legend.position = "inside", 
+    legend.position.inside = c(0, 1)
     legend.justification = c(0, 1)
   )
 
 base + 
   theme(
-    legend.position = c(0.5, 0.5), 
+    legend.position = "inside",    
+    legend.position.inside = c(0.5, 0.5), 
     legend.justification = c(0.5, 0.5)
   )
 
 base + 
   theme(
-    legend.position = c(1, 0), 
+    legend.position = "inside",
+    legend.position.inside = c(1, 0), 
     legend.justification = c(1, 0)
   )
 ```


### PR DESCRIPTION
Update the usage of legend.position.  From the [ggplot2 3.5.0 changelog]( https://ggplot2.tidyverse.org/news/index.html#ggplot2-350): Providing a numeric vector to theme(legend.position) has been deprecated. To set the default legend position inside the plot use theme(legend.position = "inside", legend.position.inside = c(...)) instead.