### PR TITLE
Update themes.qmd

### DIFF
--- a/themes.qmd
+++ b/themes.qmd
@@ -87,7 +87,8 @@ styled <- labelled +
       colour = "white"
     ),
     legend.justification = c(0, 1),
-    legend.position = c(0, 1),
+    legend.position = "inside",
+    legend.position.inside = c(0, 1),
     axis.ticks = element_line(colour = "grey70", linewidth = 0.2),
     panel.grid.major = element_line(colour = "grey70", linewidth = 0.2),
     panel.grid.minor = element_blank()


### PR DESCRIPTION
The legend.position usage should be change for the update of ggplot3.5.0. From the ggplot2 3.5.0 https://ggplot2.tidyverse.org/news/index.html#ggplot2-350, Providing a numeric vector to theme(legend.position) has been deprecated. To set the default legend position inside the plot use theme(legend.position = "inside", legend.position.inside = c(...)) instead.